### PR TITLE
Add missing joserfc dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -23,12 +23,14 @@ requirements:
     - python >={{ python_min }}
     - requests
     - cryptography
+    - joserfc >=1.6
 
 test:
   requires:
     - python {{ python_min }}
   imports:
     - authlib
+    - authlib.integrations.base_client
 
 about:
   home: https://github.com/lepture/authlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
+    - setuptools
   run:
     - python >={{ python_min }}
     - requests


### PR DESCRIPTION
authlib 1.7.0 depends on the new package joserfc. This dependency is missing, making the currently published authlib 1.7.0 unusable in most cases, as imports fail that try to import joserfc.

Note that joserfc is already built via https://github.com/conda-forge/joserfc-feedstock

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
